### PR TITLE
The range of 's_i' depends only on the output range, not on the input one.

### DIFF
--- a/lecture8.md
+++ b/lecture8.md
@@ -130,7 +130,7 @@ Following Bahdanau et al. (2014), the encoder is specified as a bidirectional RN
 $$\mathbf{h}\_i = (\overrightarrow{\mathbf{h}}\_i, \overleftarrow{\mathbf{h}}\_i)$$
 for $i = 1, \ldots, T$, where $\overrightarrow{\mathbf{h}}\_i$ and $\overleftarrow{\mathbf{h}}\_i$ respectively denote the forward and backward hidden recurrent states of the bidirectional RNN.
 
-From this, they compute a new process $\mathbf{s}\_i$, $i=1, \ldots, T$, which looks at weighted averages of the $\mathbf{h}\_j$ where the __weights are functions of the signal__.
+From this, they compute a new process $\mathbf{s}\_i$, $i=1, \ldots, T'$, which looks at weighted averages of the $\mathbf{h}\_j$ where the __weights are functions of the signal__.
 
 .footnote[Credits: Francois Fleuret, [Deep Learning](https://fleuret.org/dlc/), UNIGE/EPFL.]
 


### PR DESCRIPTION
I think the range of $s_i$ should be $s_i, i = 1, ..., T'$ where $y_i, i = 1, ..., T'$.
And not $s_i = 1, ..., T$, because the purpose of this process is to calculate the next output token $y_i$, and the size of the output ($T'$) is not necessarily the same as the size of the input ($T$).